### PR TITLE
refactor/Convert applications to list array instead of object

### DIFF
--- a/app/(app)/analytics/page.tsx
+++ b/app/(app)/analytics/page.tsx
@@ -14,9 +14,8 @@ import useApplicationsStore from "@/store/applications/useApplicationsStore";
 
 export default function Analytics() {
   const { applications } = useApplicationsStore();
-  const applicationsList = Object.values(applications);
 
-  const applicationsData = Object.values(applicationsList).reduce(
+  const applicationsData = applications.reduce(
     (acc, curr) => {
       acc[curr.status] = (acc[curr.status] || 0) + 1;
       return acc;

--- a/components/FilterSection.tsx
+++ b/components/FilterSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { CalendarIcon, ChevronDown } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import type { DateRange } from "react-day-picker";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
@@ -32,14 +32,7 @@ const defaultStatus: Record<StatusType, boolean> = {
 };
 
 const FilterSection = () => {
-  const applicationsObject = useApplicationsStore(
-    (state) => state.applications,
-  );
-
-  const applications = useMemo(
-    () => Object.values(applicationsObject),
-    [applicationsObject],
-  );
+  const applications = useApplicationsStore((state) => state.applications);
 
   const sortedApplications = [...applications].sort((a, b) =>
     b.date.localeCompare(a.date),

--- a/components/applications/ApplicationDetails.tsx
+++ b/components/applications/ApplicationDetails.tsx
@@ -35,7 +35,9 @@ type StatusVariant =
   | "rejected";
 
 const ApplicationDetails = ({ id }: { id: string }) => {
-  const application = useApplicationsStore((state) => state.applications[id]);
+  const application = useApplicationsStore((state) =>
+    state.applications.find((app) => app.id === id),
+  );
   const [editingApplication, setEditingApplication] =
     useState<Application | null>(null);
 

--- a/components/applications/ApplicationsList.tsx
+++ b/components/applications/ApplicationsList.tsx
@@ -9,7 +9,7 @@ import useApplicationsStore from "@/store/applications/useApplicationsStore";
 const ApplicationsList = () => {
   const applications = useApplicationsStore((state) => state.applications);
 
-  if (!applications || Object.values(applications).length <= 0) {
+  if (!applications || applications.length <= 0) {
     // TODO: improve this
     return (
       <div className="flex flex-col items-center pt-40">
@@ -27,7 +27,7 @@ const ApplicationsList = () => {
   return (
     <section>
       <ul>
-        {Object.values(applications).map((app) => {
+        {applications.map((app) => {
           return (
             <li key={app.id} className="cursor-pointer">
               <Link href={`/applications/${app.id}`} className="py-4 block">

--- a/components/ui/ApplicationStatusDropDown.tsx
+++ b/components/ui/ApplicationStatusDropDown.tsx
@@ -22,7 +22,7 @@ export function ApplicationStatusDropDown({ applicationId }: Props) {
     (state) => state,
   );
 
-  const application = applications[applicationId];
+  const application = applications.find((app) => app.id === applicationId);
 
   if (!application) return null;
 

--- a/store/applications/data.ts
+++ b/store/applications/data.ts
@@ -1,8 +1,8 @@
 import { type Application, ApplicationStatus } from "./types";
 
 // fake applications until we make it dynamic
-export const INITIAL_APPLICATIONS: Record<string, Application> = {
-  "app-1": {
+export const INITIAL_APPLICATIONS: Application[] = [
+  {
     id: "app-1",
     companyName: "Starlight Labs",
     role: "Product Designer",
@@ -11,7 +11,7 @@ export const INITIAL_APPLICATIONS: Record<string, Application> = {
     location: "Remote",
     notes: "Referred by Alex from the design community.",
   },
-  "app-2": {
+  {
     id: "app-2",
     companyName: "Neonbyte Health",
     role: "Frontend Engineer",
@@ -20,7 +20,7 @@ export const INITIAL_APPLICATIONS: Record<string, Application> = {
     location: "Berlin, Germany",
     notes: "Technical interview scheduled for next week.",
   },
-  "app-3": {
+  {
     id: "app-3",
     companyName: "Willow Financial",
     role: "Frontend Engineer",
@@ -29,7 +29,7 @@ export const INITIAL_APPLICATIONS: Record<string, Application> = {
     location: "London, UK",
     notes: "Offer received, negotiating compensation.",
   },
-  "app-4": {
+  {
     id: "app-4",
     companyName: "Pioneer AI",
     role: "Machine Learning Engineer",
@@ -38,7 +38,7 @@ export const INITIAL_APPLICATIONS: Record<string, Application> = {
     location: "San Francisco, CA",
     notes: "Rejected after final round, good feedback for next time.",
   },
-  "app-5": {
+  {
     id: "app-5",
     companyName: "Catalyst Studios",
     role: "Growth Marketing Lead",
@@ -47,4 +47,4 @@ export const INITIAL_APPLICATIONS: Record<string, Application> = {
     location: "New York, NY",
     notes: "Applied via company website, awaiting response.",
   },
-};
+];

--- a/store/applications/types.ts
+++ b/store/applications/types.ts
@@ -16,7 +16,7 @@ export interface Application {
 }
 
 export interface ApplicationsState {
-  applications: Record<string, Application>;
+  applications: Application[];
   addApplication: (application: Application) => void;
   updateApplication: (id: string, payload: Partial<Application>) => void;
   removeApplication: (id: string) => void;

--- a/store/applications/useApplicationsStore.tsx
+++ b/store/applications/useApplicationsStore.tsx
@@ -4,14 +4,15 @@ import { immer } from "zustand/middleware/immer";
 import { INITIAL_APPLICATIONS } from "./data";
 import type { Application, ApplicationsState } from "./types";
 
+const STORAGE_KEY = "aplico-store";
+
 const addApplication = (state: ApplicationsState, application: Application) => {
-  state.applications[application.id] = application;
-  return state;
+  state.applications.push(application);
 };
 
 const removeApplication = (state: ApplicationsState, id: string) => {
-  delete state.applications[id];
-  return state;
+  const index = state.applications.findIndex((app) => app.id === id);
+  if (index !== -1) state.applications.splice(index, 1);
 };
 
 const updateApplication = (
@@ -19,20 +20,21 @@ const updateApplication = (
   id: string,
   payload: Partial<Application>,
 ) => {
-  if (!state.applications[id]) return;
-  state.applications[id] = { ...state.applications[id], ...payload };
+  const index = state.applications.findIndex((app) => app.id === id);
+  if (index === -1) return;
+  state.applications[index] = { ...state.applications[index], ...payload };
 };
 
 const resetApplications = (state: ApplicationsState) => {
   state.applications = INITIAL_APPLICATIONS;
 };
 
-const getInitialData = () => {
+const getInitialData = (): Application[] => {
   if (typeof window === "undefined") return [];
 
   try {
     const storeInLocalStorage = JSON.parse(
-      localStorage.getItem("store") || "null",
+      localStorage.getItem(STORAGE_KEY) || "null",
     );
 
     return storeInLocalStorage?.state?.applications || INITIAL_APPLICATIONS;
@@ -54,7 +56,7 @@ const useApplicationsStore = create<ApplicationsState>()(
       resetApplications: () => set(resetApplications),
     })),
     {
-      name: "store",
+      name: STORAGE_KEY,
     },
   ),
 );


### PR DESCRIPTION
This PR refactors code to use applications as an array instead of an object to make it easier to loop through applications instead of depending on `Object.Values` in many places.